### PR TITLE
add handling of MultiSigOwnerAddition event

### DIFF
--- a/src/luw-mapping.ts
+++ b/src/luw-mapping.ts
@@ -1,31 +1,55 @@
-
 import { Bytes, log } from '@graphprotocol/graph-ts'
 
-import { CreateLicensedUserWallet as CreateLUWEvent } from '../generated/LicensedUserEvent/LicensedUserEvent'
+import {
+  CreateLicensedUserWallet as CreateLUWEvent,
+  MultiSigOwnerAddition as MultiSigOwnerAdditionEvent,
+} from '../generated/LicensedUserEvent/LicensedUserEvent'
 import { LicensedUserWallet } from '../generated/schema'
 import { eventUTCMillis } from './utils'
 
 export function userType(n: i32): string {
   switch (n) {
-    case 0: return 'admin';
-    case 1: return 'handler';
-    case 2: return 'artist';
-    default: 
-      log.error(`unhandled userType: {}`, [n.toString()])
-      return '';
+    case 0:
+      return "admin";
+    case 1:
+      return "handler";
+    case 2:
+      return "artist";
+    default:
+      log.error(`unhandled userType: {}`, [n.toString()]);
+      return "";
   }
 }
 export function handleCreateLicensedUserWallet(event: CreateLUWEvent): void {
-  let luwId = event.params.contractAddress.toHexString()
-  
-  let luw = new LicensedUserWallet(luwId)
-  luw.contractAddress = event.params.contractAddress
-  luw.requiredConfirmation = event.params.requiredConfirmation.toI32()
-  luw.englishName = event.params.englishName
-  luw.originalName = event.params.originalName
-  luw.owners = event.params.owners as Array<Bytes>
-  luw.userType = userType(event.params.userType)
-  luw.createdAt = luw.updatedAt = eventUTCMillis(event)
- 
-  luw.save()
+  let luwId = event.params.contractAddress.toHexString();
+
+  let luw = new LicensedUserWallet(luwId);
+  luw.contractAddress = event.params.contractAddress;
+  luw.requiredConfirmation = event.params.requiredConfirmation.toI32();
+  luw.englishName = event.params.englishName;
+  luw.originalName = event.params.originalName;
+  luw.owners = event.params.owners as Array<Bytes>;
+  luw.userType = userType(event.params.userType);
+  luw.createdAt = luw.updatedAt = eventUTCMillis(event);
+
+  luw.save();
+}
+
+export function handleOwnerAddition(event: MultiSigOwnerAdditionEvent): void {
+  let luwId = event.params.proxyContractAddr.toHexString();
+  let luw = LicensedUserWallet.load(luwId);
+  if (luw == null) {
+    log.error("received event for unknown LUW: {}", [luwId]);
+    return;
+  }
+
+  log.info("adding owner {}", [event.params.owner.toHexString()]);
+  // this 3 step assign, push, reassign is necessary here:
+  // (see https://thegraph.com/docs/assemblyscript-api#api-reference):
+  let owners = luw.owners;
+  owners.push(event.params.owner);
+  luw.owners = owners;
+
+  luw.updatedAt = eventUTCMillis(event);
+  luw.save();
 }

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -23,6 +23,8 @@ dataSources:
       eventHandlers:
         - event: CreateLicensedUserWallet(indexed address,address[],uint256,string,string,uint8)
           handler: handleCreateLicensedUserWallet
+        - event: MultiSigOwnerAddition(indexed address,indexed address)
+          handler: handleOwnerAddition
       file: ./src/luw-mapping.ts
 
   - kind: ethereum/contract


### PR DESCRIPTION
Indexed with local graph-node:
```
graph-node_1  | Jan 14 09:20:16.220 INFO adding owner 0x812a2d41ce1fd60c7042810b51f7df95dd7a5b5d, data_source: LicensedUserEvent, runtime_host: 1/1, block_hash: 0xb70729ad2971fc14b78ca144c3cbe6d5c0f043559122830faf046e08d066d5ba, block_number: 11651714, subgraph_id: QmUwAAC44eguvKh9QzvXHn8dUi4rRdMiLBdgzWP2C1Y32o, component: SubgraphInstanceManager

graph-node_1  | Jan 14 09:20:16.221 INFO Done processing Ethereum trigger, waiting_ms: 0, handler: handleOwnerAddition, total_ms: 1, trigger_type: Log, address: 0x2a07…5912, signature: MultiSigOwnerAddition(indexed address,indexed address), runtime_host: 1/1, block_hash: 0xb70729ad2971fc14b78ca144c3cbe6d5c0f043559122830faf046e08d066d5ba, block_number: 11651714, subgraph_id: QmUwAAC44eguvKh9QzvXHn8dUi4rRdMiLBdgzWP2C1Y32o, component: SubgraphInstanceManager
```