### PR TITLE
upgrade node to 14.15.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: circleci/node:12.18.2
+      - image: circleci/node:14.15.4
 
 commands:
   install_node_dependencies:


### PR DESCRIPTION
pick up the latest security patch release
also consistent with node version used in other repos