### PR TITLE
STARTRAIL-799 fix provenance handler

### DIFF
--- a/src/srr-mapping.ts
+++ b/src/srr-mapping.ts
@@ -10,7 +10,6 @@ import {
 
 import {
   CreateSRR as CreateSRREvent,
-  Provenance as SRRProvenanceEvent,
   SRRCommitment as SRRCommitmentEvent,
   SRRCommitmentCancelled as SRRCommitmentCancelledEvent,
   UpdateSRR as UpdateSRREvent,
@@ -29,6 +28,7 @@ import {
 import {
   CreateCustomHistory as CustomHistoryCreatedEvent,
   CreateCustomHistoryType as CustomHistoryTypeCreatedEvent,
+  Provenance as SRRProvenanceEvent,
   Provenance1 as SRRProvenanceWithCustomHistoryEvent,
   SRRCommitment1 as SRRCommitmentWithCustomHistoryEvent,
   Transfer as TransferEvent,

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -117,8 +117,6 @@ dataSources:
           handler: handleCreateSRR
         - event: UpdateSRR(indexed uint256,(bool,address,address))
           handler: handleUpdateSRR
-        - event: Provenance(indexed uint256,indexed address,indexed address,uint256,string,string)
-          handler: handleSRRProvenance
         - event: SRRCommitment(address,bytes32,uint256)
           handler: handleSRRCommitment
         - event: SRRCommitmentCancelled(uint256)


### PR DESCRIPTION
[related issue.](https://startbahn.atlassian.net/browse/STARTRAIL-799)

in rinkeby-develop, provenanceHandler failed at the block number 8242287.
We need to specify the block number 8242287 as the startBlock and deploy it again.

- [x] remove handerSRRProvenance from RootLogic
- [x] use Provenance class instead of RootLogic one