### PR TITLE
API-1234 set correct self hosted url in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "deploy-gke-develop": "npm run generate-develop && graph deploy --ipfs https://subgraph.startbahn.jp/ipfs/ --node https://subgraph.startbahn.jp/admin/ startbahn/startrail-mumbai-develop subgraph.mumbai-develop.yaml",
     "deploy-gke-release": "npm run generate-release && graph deploy --ipfs https://subgraph.startbahn.jp/ipfs/ --node https://subgraph.startbahn.jp/admin/ startbahn/startrail-mumbai-release subgraph.mumbai-release.yaml",
     "deploy-gke-master": "npm run generate-master && graph deploy --ipfs https://subgraph.startrail.io/ipfs/ --node https://subgraph.startrail.io/admin/ startbahn/startrail subgraph.mainnet.yaml",
-    "deploy-gke-polygon": "npm run generate-polygon && graph deploy --ipfs https://subgraph.startrail.io/ipfs/ --node https://subgraph.startrail.io/admin/ startbahn/startrail-polygon subgraph.polygon.yaml",
+    "deploy-gke-polygon": "npm run generate-polygon && graph deploy --ipfs https://subgraph.startrail.io/ipfs/ --node https://subgraph-lum.startrail.io/admin/ startbahn/startrail-polygon subgraph.polygon.yaml",
     "deploy-develop": "npm run generate-develop && graph deploy --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ startbahn/startrail-mumbai-develop --access-token $TOKEN subgraph.mumbai-develop.yaml",
     "deploy-release": "npm run generate-release && graph deploy --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ startbahn/startrail-mumbai-release --access-token $TOKEN subgraph.mumbai-release.yaml",
     "deploy-master": "npm run generate-master && graph deploy --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ startbahn/startrail --access-token $TOKEN subgraph.mainnet.yaml",


### PR DESCRIPTION
regarding release for bulk transfer, I found that self hosted subgraph url was invalid.  the url subgraph.startrail.io is still pointing address to mainnet(ethereum)