### PR TITLE
STARTRAIL-932 point to hardhat at 8546

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       postgres_db: graph-node
       ipfs: "ipfs:5001"
       RUST_LOG: info
-      ethereum: "local:http://startrail-hardhat:8545"
+      ethereum: "local:http://startrail-hardhat:8546"
 
   ipfs:
     container_name: subgraph-ipfs


### PR DESCRIPTION
Sync with Startrail change that moves Ethereum JSONRPC port to 8546.