### PR TITLE
@startbahn/startrail:1.7.0-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "js-yaml": "^3.14.0"
   },
   "dependencies": {
-    "@startbahn/startrail": "1.7.0-rc1",
+    "@startbahn/startrail": "1.7.0-rc2",
     "babel-polyfill": "^6.26.0",
     "babel-register": "^6.26.0"
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "js-yaml": "^3.14.0"
   },
   "dependencies": {
-    "@startbahn/startrail": "1.8.0-beta-3",
+    "@startbahn/startrail": "1.7.0-rc1",
     "babel-polyfill": "^6.26.0",
     "babel-register": "^6.26.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@startbahn/startrail@1.7.0-rc1":
-  version "1.7.0-rc1"
-  resolved "https://registry.yarnpkg.com/@startbahn/startrail/-/startrail-1.7.0-rc1.tgz#b4d07248e79c7202541df730851c44effcd08c54"
-  integrity sha512-0O8MuKkuJDUuwO+mA6u0zG8u7m116zlX9guzwLi95cyC8SJGDM9IbMC1zrduGpA0a7uLyOSvRtCYXurXS88GYw==
+"@startbahn/startrail@1.7.0-rc2":
+  version "1.7.0-rc2"
+  resolved "https://registry.yarnpkg.com/@startbahn/startrail/-/startrail-1.7.0-rc2.tgz#d5349255b9e3931e1b384d9a7162f03409d4f3fa"
+  integrity sha512-Es14e2lK2W4zf9jOj/9QSyVLfZul4tfGC2q17MdmAIVIDeiAW+FfGBXoxFZtLjEWv6mjK6mgAOyigIljNH8Wpw==
 
 "@types/connect@^3.4.33":
   version "3.4.34"

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@startbahn/startrail@1.8.0-beta-3":
-  version "1.8.0-beta-3"
-  resolved "https://registry.yarnpkg.com/@startbahn/startrail/-/startrail-1.8.0-beta-3.tgz#d32cc2a5f23ab918a137e30082f63ffe5c19efe3"
-  integrity sha512-wEks3kB2bmEKXnYKI8wLfkm3+99wNOjo7Xp2iNnfCK4wmB3GJkwPu+L9iF/lTRLCiTAMv1jC4sExgYJiKV9o6A==
+"@startbahn/startrail@1.7.0-rc1":
+  version "1.7.0-rc1"
+  resolved "https://registry.yarnpkg.com/@startbahn/startrail/-/startrail-1.7.0-rc1.tgz#b4d07248e79c7202541df730851c44effcd08c54"
+  integrity sha512-0O8MuKkuJDUuwO+mA6u0zG8u7m116zlX9guzwLi95cyC8SJGDM9IbMC1zrduGpA0a7uLyOSvRtCYXurXS88GYw==
 
 "@types/connect@^3.4.33":
   version "3.4.34"


### PR DESCRIPTION
Update the startrail dependency to pick up ABIs for provenance fix deployment.