### PR TITLE
Feature/startrail 1060

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Example queries can be selected in the GraphQL playground here:
 ![Subgraph examples dropdown](./subgraph.png)
 
 See also the Startrail API startrail-graph-client module which has predefined queries used by the API.
+
+# Subgraph unit test
+
+When testing subgraphs, you should run seed-extended instead of seed-minimal. See ./bin/hardhat-and-graph-up.sh in startrail-metarepo.

--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ See also the Startrail API startrail-graph-client module which has predefined qu
 
 # Subgraph unit test
 
-When testing subgraphs, you should run seed-extended instead of seed-minimal. See ./bin/hardhat-and-graph-up.sh in startrail-metarepo.
+When testing subgraphs, you should run seed-extended instead of seed-minimal. See ./bin/hardhat-and-graph-up.sh in startrail-metarepo.  
+(Sorry startrail-metarepo repository is private!)

--- a/src/srr-mapping.ts
+++ b/src/srr-mapping.ts
@@ -719,10 +719,8 @@ export function handleMigrateSRR(event: MigrateSRREvent): void {
   logInvocation("handleMigrateSRR", event);
   let srrId = event.params.tokenId.toString();
   let srr = SRR.load(srrId);
-  if (srr) {
-    srr.originChain = event.params.originChain;
-    srr.save();  
-  }
+  srr.originChain = event.params.originChain;
+  srr.save();
 }
 
 export function handleProvenanceDateMigrationFix(

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -43,15 +43,6 @@ test("srrs", async () => {
 
   const data = [
     expect.objectContaining({
-      history: [],
-      id: "10255373",
-      metadataDigest:
-        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
-      originChain: "eip155:31337",
-      tokenId: "10255373",
-      transferCommitment: null
-    }),
-    expect.objectContaining({
       history: [
         {
           id:
@@ -67,11 +58,11 @@ test("srrs", async () => {
     }),
     expect.objectContaining({
       history: [],
-      id: "80626184",
+      id: "55806818",
       metadataDigest:
         "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
       originChain: "eip155:31337",
-      tokenId: "80626184",
+      tokenId: "55806818",
       transferCommitment: null
     })
   ]
@@ -113,15 +104,7 @@ test("licensedUserWallets ", async () => {
   const data = [
     {
       englishName: "Artist English",
-      issuedSRRs: [
-        {
-          id: "80626184",
-          metadataDigest:
-            "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
-          tokenId: "80626184",
-          transferCommitment: null
-        }
-      ],
+      issuedSRRs: [],
       originChain: null,
       originalName: "Artist Original",
       owners: [
@@ -138,17 +121,17 @@ test("licensedUserWallets ", async () => {
       englishName: "New English Name",
       issuedSRRs: [
         {
-          id: "10255373",
-          metadataDigest:
-            "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
-          tokenId: "10255373",
-          transferCommitment: null
-        },
-        {
           id: "43593516",
           metadataDigest:
             "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
           tokenId: "43593516",
+          transferCommitment: null
+        },
+        {
+          id: "55806818",
+          metadataDigest:
+            "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
+          tokenId: "55806818",
           transferCommitment: null
         }
       ],
@@ -218,17 +201,17 @@ test("srrmetadataHistories", async () => {
   const data = [
     {
       metadataDigest:
-        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
+        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
       srr: {
         metadataDigest:
-          "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
+          "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
         metadataHistory: [
           {
             metadataDigest:
-              "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
+              "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
             srr: {
               metadataDigest:
-                "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252"
+                "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251"
             }
           }
         ],
@@ -249,26 +232,6 @@ test("srrmetadataHistories", async () => {
             srr: {
               metadataDigest:
                 "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64"
-            }
-          }
-        ],
-        originChain: "eip155:31337",
-        transferCommitment: null
-      }
-    },
-    {
-      metadataDigest:
-        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
-      srr: {
-        metadataDigest:
-          "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
-        metadataHistory: [
-          {
-            metadataDigest:
-              "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
-            srr: {
-              metadataDigest:
-                "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251"
             }
           }
         ],
@@ -351,6 +314,13 @@ test("metaTxRequestTypes", async () => {
         "StartrailRegistryCreateSRR(address from,uint256 nonce,bool isPrimaryIssuer,address artistAddress,bytes32 metadataDigest)"
     },
     {
+      id: "0xa5772716d883ea9d1e653c127fc4b5f193148ae32c6699efdcdba6fa2a242f4f",
+      typeHash: 
+        "0xa5772716d883ea9d1e653c127fc4b5f193148ae32c6699efdcdba6fa2a242f4f",
+      typeString: 
+        "StartrailRegistryUpdateSRRMetadataV2(address from,uint256 nonce,bytes data,uint256 tokenId,string metadataDigest)",
+    },
+    {
       id: "0xb4d22bf06a762d0a27f1c25c8a258e0982dbc92abe4d6d72fdbec60d49464daa",
       typeHash:
         "0xb4d22bf06a762d0a27f1c25c8a258e0982dbc92abe4d6d72fdbec60d49464daa",
@@ -363,6 +333,13 @@ test("metaTxRequestTypes", async () => {
         "0xd111846f191cf3c32ce6aedccf704a641a50381f22729d5a6cd5f13a0554ef80",
       typeString:
         "StartrailRegistryUpdateSRRMetadata(address from,uint256 nonce,uint256 tokenId,bytes32 metadataDigest)"
+    },
+    {
+      id: "0xe0ff2c72dcc273eb61555bd35aa1b25a97a14163d68e843f798a5763111780be",
+      typeHash: 
+        "0xe0ff2c72dcc273eb61555bd35aa1b25a97a14163d68e843f798a5763111780be",
+      typeString: 
+        "StartrailRegistryCreateSRRV2(address from,uint256 nonce,bytes data,bool isPrimaryIssuer,address artistAddress,string metadataDigest)",
     },
     {
       id: "0xe40b02b26d5443f4479036538f991a995624f5cc199ecab72a0dde126115a16c",
@@ -459,7 +436,7 @@ test("srrprovenances", async () => {
       metadataURI:
         "https://api.startrail.io/api/v1/metadata/ba136728b9ccfc56aa07d354fb7b5b026fa8123ad74f2fdb7a938bdf08c77a70.json",
       srr: {
-        id: "10255373"
+        id: "55806818"
       }
     },
     {
@@ -472,6 +449,15 @@ test("srrprovenances", async () => {
       srr: {
         id: "43593516"
       }
+    },
+    {
+      customHistory: null,
+      isIntermediary: false,
+      metadataDigest: "0x",
+      metadataURI: "",
+      srr: {
+        id: "55806818",
+      },
     }
   ]
 
@@ -494,12 +480,12 @@ test("srrtransferCommits", async () => {
   const data = [
     {
       commitment: null,
-      id: "10255373",
+      id: "43593516",
       lastAction: "transfer"
     },
     {
       commitment: null,
-      id: "43593516",
+      id: "55806818",
       lastAction: "transfer"
     }
   ]

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -43,6 +43,15 @@ test("srrs", async () => {
 
   const data = [
     expect.objectContaining({
+      history: [],
+      id: "10255373",
+      metadataDigest:
+        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
+      originChain: "eip155:31337",
+      tokenId: "10255373",
+      transferCommitment: null
+    }),
+    expect.objectContaining({
       history: [
         {
           id:
@@ -58,11 +67,11 @@ test("srrs", async () => {
     }),
     expect.objectContaining({
       history: [],
-      id: "55806818",
+      id: "80626184",
       metadataDigest:
         "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
       originChain: "eip155:31337",
-      tokenId: "55806818",
+      tokenId: "80626184",
       transferCommitment: null
     })
   ]
@@ -104,7 +113,14 @@ test("licensedUserWallets ", async () => {
   const data = [
     {
       englishName: "Artist English",
-      issuedSRRs: [],
+      issuedSRRs: [
+        {
+          id: "80626184",
+          metadataDigest: "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
+          tokenId: "80626184",
+          transferCommitment: null,
+        }
+      ],
       originChain: null,
       originalName: "Artist Original",
       owners: [
@@ -121,17 +137,17 @@ test("licensedUserWallets ", async () => {
       englishName: "New English Name",
       issuedSRRs: [
         {
+          id: "10255373",
+          metadataDigest:
+            "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
+          tokenId: "10255373",
+          transferCommitment: null
+        },
+        {
           id: "43593516",
           metadataDigest:
             "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
           tokenId: "43593516",
-          transferCommitment: null
-        },
-        {
-          id: "55806818",
-          metadataDigest:
-            "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
-          tokenId: "55806818",
           transferCommitment: null
         }
       ],
@@ -201,17 +217,17 @@ test("srrmetadataHistories", async () => {
   const data = [
     {
       metadataDigest:
-        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
+        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
       srr: {
         metadataDigest:
-          "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
+          "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
         metadataHistory: [
           {
             metadataDigest:
-              "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
+              "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
             srr: {
               metadataDigest:
-                "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251"
+                "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252"
             }
           }
         ],
@@ -232,6 +248,26 @@ test("srrmetadataHistories", async () => {
             srr: {
               metadataDigest:
                 "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64"
+            }
+          }
+        ],
+        originChain: "eip155:31337",
+        transferCommitment: null
+      }
+    },
+    {
+      metadataDigest:
+        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
+      srr: {
+        metadataDigest:
+          "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
+        metadataHistory: [
+          {
+            metadataDigest:
+              "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
+            srr: {
+              metadataDigest:
+                "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251"
             }
           }
         ],
@@ -314,13 +350,6 @@ test("metaTxRequestTypes", async () => {
         "StartrailRegistryCreateSRR(address from,uint256 nonce,bool isPrimaryIssuer,address artistAddress,bytes32 metadataDigest)"
     },
     {
-      id: "0xa5772716d883ea9d1e653c127fc4b5f193148ae32c6699efdcdba6fa2a242f4f",
-      typeHash: 
-        "0xa5772716d883ea9d1e653c127fc4b5f193148ae32c6699efdcdba6fa2a242f4f",
-      typeString: 
-        "StartrailRegistryUpdateSRRMetadataV2(address from,uint256 nonce,bytes data,uint256 tokenId,string metadataDigest)",
-    },
-    {
       id: "0xb4d22bf06a762d0a27f1c25c8a258e0982dbc92abe4d6d72fdbec60d49464daa",
       typeHash:
         "0xb4d22bf06a762d0a27f1c25c8a258e0982dbc92abe4d6d72fdbec60d49464daa",
@@ -333,13 +362,6 @@ test("metaTxRequestTypes", async () => {
         "0xd111846f191cf3c32ce6aedccf704a641a50381f22729d5a6cd5f13a0554ef80",
       typeString:
         "StartrailRegistryUpdateSRRMetadata(address from,uint256 nonce,uint256 tokenId,bytes32 metadataDigest)"
-    },
-    {
-      id: "0xe0ff2c72dcc273eb61555bd35aa1b25a97a14163d68e843f798a5763111780be",
-      typeHash: 
-        "0xe0ff2c72dcc273eb61555bd35aa1b25a97a14163d68e843f798a5763111780be",
-      typeString: 
-        "StartrailRegistryCreateSRRV2(address from,uint256 nonce,bytes data,bool isPrimaryIssuer,address artistAddress,string metadataDigest)",
     },
     {
       id: "0xe40b02b26d5443f4479036538f991a995624f5cc199ecab72a0dde126115a16c",
@@ -376,6 +398,20 @@ test("metaTxRequestTypes", async () => {
       typeString:
         "WalletChangeThreshold(address from,uint256 nonce,address wallet,uint256 threshold)"
     }
+    // {
+    //   id: "0xa5772716d883ea9d1e653c127fc4b5f193148ae32c6699efdcdba6fa2a242f4f",
+    //   typeHash: 
+    //     "0xa5772716d883ea9d1e653c127fc4b5f193148ae32c6699efdcdba6fa2a242f4f",
+    //   typeString: 
+    //     "StartrailRegistryUpdateSRRMetadataV2(address from,uint256 nonce,bytes data,uint256 tokenId,string metadataDigest)",
+    // },
+    // {
+    //   id: "0xe0ff2c72dcc273eb61555bd35aa1b25a97a14163d68e843f798a5763111780be",
+    //   typeHash: 
+    //     "0xe0ff2c72dcc273eb61555bd35aa1b25a97a14163d68e843f798a5763111780be",
+    //   typeString: 
+    //     "StartrailRegistryCreateSRRV2(address from,uint256 nonce,bytes data,bool isPrimaryIssuer,address artistAddress,string metadataDigest)",
+    // },
   ]
   expect(result.metaTxRequestTypes).toStrictEqual(data)
 })
@@ -436,7 +472,7 @@ test("srrprovenances", async () => {
       metadataURI:
         "https://api.startrail.io/api/v1/metadata/ba136728b9ccfc56aa07d354fb7b5b026fa8123ad74f2fdb7a938bdf08c77a70.json",
       srr: {
-        id: "55806818"
+        id: "10255373"
       }
     },
     {
@@ -456,7 +492,7 @@ test("srrprovenances", async () => {
       metadataDigest: "0x",
       metadataURI: "",
       srr: {
-        id: "55806818",
+        id: "10255373",
       },
     }
   ]
@@ -480,12 +516,12 @@ test("srrtransferCommits", async () => {
   const data = [
     {
       commitment: null,
-      id: "43593516",
+      id: "10255373",
       lastAction: "transfer"
     },
     {
       commitment: null,
-      id: "55806818",
+      id: "43593516",
       lastAction: "transfer"
     }
   ]

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -196,7 +196,7 @@ test("customHistoryType", async () => {
 test("srrmetadataHistories", async () => {
   const query = `
   {
-    srrmetadataHistories {
+    srrmetadataHistories(orderBy: createdAt, orderDirection: desc) {
       srr {
         metadataDigest
         transferCommitment
@@ -237,26 +237,6 @@ test("srrmetadataHistories", async () => {
     },
     {
       metadataDigest:
-        "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
-      srr: {
-        metadataDigest:
-          "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
-        metadataHistory: [
-          {
-            metadataDigest:
-              "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
-            srr: {
-              metadataDigest:
-                "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64"
-            }
-          }
-        ],
-        originChain: "eip155:31337",
-        transferCommitment: null
-      }
-    },
-    {
-      metadataDigest:
         "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
       srr: {
         metadataDigest:
@@ -268,6 +248,26 @@ test("srrmetadataHistories", async () => {
             srr: {
               metadataDigest:
                 "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251"
+            }
+          }
+        ],
+        originChain: "eip155:31337",
+        transferCommitment: null
+      }
+    },
+    {
+      metadataDigest:
+        "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
+      srr: {
+        metadataDigest:
+          "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
+        metadataHistory: [
+          {
+            metadataDigest:
+              "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
+            srr: {
+              metadataDigest:
+                "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64"
             }
           }
         ],
@@ -398,6 +398,7 @@ test("metaTxRequestTypes", async () => {
       typeString:
         "WalletChangeThreshold(address from,uint256 nonce,address wallet,uint256 threshold)"
     }
+    // for decentalized storage
     // {
     //   id: "0xa5772716d883ea9d1e653c127fc4b5f193148ae32c6699efdcdba6fa2a242f4f",
     //   typeHash: 

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,10 +552,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@startbahn/startrail@1.7.0-rc1":
-  version "1.7.0-rc1"
-  resolved "https://registry.yarnpkg.com/@startbahn/startrail/-/startrail-1.7.0-rc1.tgz#b4d07248e79c7202541df730851c44effcd08c54"
-  integrity sha512-0O8MuKkuJDUuwO+mA6u0zG8u7m116zlX9guzwLi95cyC8SJGDM9IbMC1zrduGpA0a7uLyOSvRtCYXurXS88GYw==
+"@startbahn/startrail@1.7.0-rc2":
+  version "1.7.0-rc2"
+  resolved "https://registry.yarnpkg.com/@startbahn/startrail/-/startrail-1.7.0-rc2.tgz#d5349255b9e3931e1b384d9a7162f03409d4f3fa"
+  integrity sha512-Es14e2lK2W4zf9jOj/9QSyVLfZul4tfGC2q17MdmAIVIDeiAW+FfGBXoxFZtLjEWv6mjK6mgAOyigIljNH8Wpw==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -594,10 +594,6 @@
   integrity sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   dependencies:
     "@babel/types" "^7.3.0"
-"@startbahn/startrail@1.7.0-rc2":
-  version "1.7.0-rc2"
-  resolved "https://registry.yarnpkg.com/@startbahn/startrail/-/startrail-1.7.0-rc2.tgz#d5349255b9e3931e1b384d9a7162f03409d4f3fa"
-  integrity sha512-Es14e2lK2W4zf9jOj/9QSyVLfZul4tfGC2q17MdmAIVIDeiAW+FfGBXoxFZtLjEWv6mjK6mgAOyigIljNH8Wpw==
 
 "@types/connect@^3.4.33":
   version "3.4.35"
@@ -897,9 +893,9 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
+"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
-  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
+  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"


### PR DESCRIPTION
- [x] create a provenance entity when the transfer event is emitted.
- [x] fix test

I could not figure out under what conditions I should run test.
I guess it probably does something after the subgraph is up in metarepo, However, there seems to be a lack of assumed transaction there.

If we improve the test in future, I want to use this module
https://github.com/LimeChain/matchstick-as

To run the test, please set the following branch to metarepo.

```
STARTRAIL_API_BRANCH=develop
STARTRAIL_BRANCH=misc-changes-from-decent-meta-pr
SUBGRAPH_BRANCH=feature/STARTRAIL-1060
```