### PR TITLE
API-1664 add artist entity under SRR

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ See also the Startrail API startrail-graph-client module which has predefined qu
 
 # Subgraph unit test
 
-When testing subgraphs, you should run seed-extended instead of seed-minimal. See ./bin/hardhat-and-graph-up.sh in startrail-metarepo.  
+When testing subgraphs, you should run seed-extended in addition to seed-minimal. See ./bin/hardhat-and-graph-up.sh in startrail-metarepo.  
 (Sorry startrail-metarepo repository is private!)

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,6 +34,7 @@ type SRR @entity {
   id: ID! # tokenId.toString()
   tokenId: String # ERC721 token id
   isPrimaryIssuer: Boolean
+  artist: LicensedUserWallet
   artistAddress: Bytes
   issuer: LicensedUserWallet
   ownerAddress: Bytes

--- a/src/srr-mapping.ts
+++ b/src/srr-mapping.ts
@@ -193,20 +193,23 @@ function saveCreateSRRInternal(
   updateTimestamp: BigInt,
   event: ethereum.Event
 ): void {
-  srr.artistAddress = artist;
   srr.isPrimaryIssuer = isPrimaryIssuer;
   srr.metadataDigest = metadataDigest;
 
-  let issuerId = issuer.toHexString();
-  let luw = LicensedUserWallet.load(issuerId);
-  if (luw != null) {
-    srr.issuer = luw.id;
-  }
-
+  srr.artistAddress = artist;
+  srr.artist = getLicensedUserIdFromAddress(artist);
+  srr.issuer = getLicensedUserIdFromAddress(issuer);
+  
   srr.updatedAt = updateTimestamp;
   srr.save();
 
   saveSRRMetadataHistory(srr as SRR, updateTimestamp, event);
+}
+
+function getLicensedUserIdFromAddress(address: Address): string | null {
+  let id = address.toHexString();
+  let luw = LicensedUserWallet.load(id);
+  return luw == null ? null : luw.id;
 }
 
 export function handleSRRProvenance(event: SRRProvenanceEvent): void {

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -15,10 +15,14 @@ beforeAll(() => {
 test("srrs", async () => {
   const query = `
   {
-    srrs {
+    srrs(orderBy: id) {
       id
       tokenId
       artistAddress
+      artist {
+        id
+        englishName
+      }
       issuer {
         id
         englishName
@@ -26,7 +30,9 @@ test("srrs", async () => {
       metadataDigest
       transferCommitment
       history {
-        id
+        customHistory {
+          metadataDigest
+        }
       }
       originChain
     }
@@ -49,31 +55,41 @@ test("srrs", async () => {
   const data = [
     expect.objectContaining({
       history: [],
-      id: "10255373",
+      id: "57470167",
       metadataDigest:
-        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
+        "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
       originChain: "eip155:31337",
-      tokenId: "10255373",
-      artistAddress: "0xa6e6a9e20a541680a1d6e1412f5088aefbf58a22",
+      tokenId: "57470167",
+      artistAddress: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
+      artist: {
+        id: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
+        englishName: "Artist English"
+      },
       issuer: {
-        id: "0xf157e8b5d7a4b3fda8c2f7c19b4a57be32ec0392",
-        englishName: "New English Name"
+        id: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
+        englishName: "Artist English"
       },
       transferCommitment: null
     }),
     expect.objectContaining({
       history: [
         {
-          id:
-            "0xe816ba014d36a530fa00332e555613d1678221f17419b1bc9216e9af7ed98578"
+          customHistory: {
+            metadataDigest:
+            "0xcc3b6344b207c582bd727005be2a5de5bbca7b46b590d9e9189f3a9a7ea8283e"
+          }
         }
       ],
-      id: "43593516",
+      id: "60438356",
       metadataDigest:
         "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
       originChain: "eip155:31337",
-      tokenId: "43593516",
-      artistAddress: "0xa6e6a9e20a541680a1d6e1412f5088aefbf58a22",
+      tokenId: "60438356",
+      artistAddress: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
+      artist: {
+        id: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
+        englishName: "Artist English"
+      },
       issuer: {
         id: "0xf157e8b5d7a4b3fda8c2f7c19b4a57be32ec0392",
         englishName: "New English Name"
@@ -82,15 +98,19 @@ test("srrs", async () => {
     }),
     expect.objectContaining({
       history: [],
-      id: "80626184",
+      id: "67251424",
       metadataDigest:
-        "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
+        "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
       originChain: "eip155:31337",
-      tokenId: "80626184",
-      artistAddress: "0x66c0d9152209b51977047b9dc3b0b5bf2339b67c",
-      issuer: {
+      tokenId: "67251424",
+      artistAddress: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
+      artist: {
         id: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
         englishName: "Artist English"
+      },
+      issuer: {
+        id: "0xf157e8b5d7a4b3fda8c2f7c19b4a57be32ec0392",
+        englishName: "New English Name"
       },
       transferCommitment: null
     })
@@ -111,15 +131,15 @@ test("srrs", async () => {
 test("licensedUserWallets ", async () => {
   const query = `
   {
-    licensedUserWallets {
-      id
+    licensedUserWallets(orderBy: salt) {
+      walletAddress
       threshold
       englishName
       originalName
       userType
       owners
       salt
-      issuedSRRs {
+      issuedSRRs(orderBy: tokenId) {
         id
         tokenId
         metadataDigest
@@ -133,13 +153,13 @@ test("licensedUserWallets ", async () => {
 
   const data = [
     {
-      id: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
+      walletAddress: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
       englishName: "Artist English",
       issuedSRRs: [
         {
-          id: "80626184",
+          id: "57470167",
           metadataDigest: "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
-          tokenId: "80626184",
+          tokenId: "57470167",
           transferCommitment: null,
         }
       ],
@@ -156,21 +176,21 @@ test("licensedUserWallets ", async () => {
       userType: "artist"
     },
     {
-      id: "0xf157e8b5d7a4b3fda8c2f7c19b4a57be32ec0392",
+      walletAddress: "0xf157e8b5d7a4b3fda8c2f7c19b4a57be32ec0392",
       englishName: "New English Name",
       issuedSRRs: [
         {
-          id: "10255373",
+          id: "60438356",
           metadataDigest:
-            "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
-          tokenId: "10255373",
+            "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
+          tokenId: "60438356",
           transferCommitment: null
         },
         {
-          id: "43593516",
+          id: "67251424",
           metadataDigest:
-            "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
-          tokenId: "43593516",
+            "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
+          tokenId: "67251424",
           transferCommitment: null
         }
       ],
@@ -485,7 +505,7 @@ test("srrprovenances", async () => {
       metadataURI:
         "https://api.startrail.io/api/v1/metadata/ba136728b9ccfc56aa07d354fb7b5b026fa8123ad74f2fdb7a938bdf08c77a70.json",
       srr: {
-        id: "43593516"
+        id: "60438356"
       }
     },
     {
@@ -496,7 +516,7 @@ test("srrprovenances", async () => {
       metadataURI:
         "https://api.startrail.io/api/v1/metadata/ba136728b9ccfc56aa07d354fb7b5b026fa8123ad74f2fdb7a938bdf08c77a70.json",
       srr: {
-        id: "10255373"
+        id: "67251424"
       }
     },
     {
@@ -507,7 +527,7 @@ test("srrprovenances", async () => {
       metadataURI:
         "https://api.startrail.io/api/v1/metadata/ba136728b9ccfc56aa07d354fb7b5b026fa8123ad74f2fdb7a938bdf08c77a70.json",
       srr: {
-        id: "43593516"
+        id: "60438356"
       }
     },
     {
@@ -516,7 +536,7 @@ test("srrprovenances", async () => {
       metadataDigest: "0x",
       metadataURI: "",
       srr: {
-        id: "10255373",
+        id: "67251424",
       },
     }
   ]
@@ -540,12 +560,12 @@ test("srrtransferCommits", async () => {
   const data = [
     {
       commitment: null,
-      id: "10255373",
+      id: "60438356",
       lastAction: "transfer"
     },
     {
       commitment: null,
-      id: "43593516",
+      id: "67251424",
       lastAction: "transfer"
     }
   ]
@@ -593,7 +613,9 @@ test("customHistories", async () => {
       name
       metadataDigest
       srrHistory {
-        id
+        srr {
+          id
+        }
       }
       originChain
     }
@@ -614,8 +636,9 @@ test("customHistories", async () => {
       originChain: "eip155:31337",
       srrHistory: [
         {
-          id:
-            "0xe816ba014d36a530fa00332e555613d1678221f17419b1bc9216e9af7ed98578"
+          srr: {
+            id: "60438356"
+          }
         }
       ]
     }
@@ -629,7 +652,6 @@ test("srrHistories", async () => {
   const query = `
   {
     srrhistories {
-      id
       srr {
         id
       }
@@ -646,9 +668,8 @@ test("srrHistories", async () => {
       customHistory: {
         id: "1"
       },
-      id: "0xe816ba014d36a530fa00332e555613d1678221f17419b1bc9216e9af7ed98578",
       srr: {
-        id: "43593516"
+        id: "60438356"
       }
     }
   ]

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -11,13 +11,18 @@ beforeAll(() => {
   })
 })
 
-// ignoring createdAt and updatedAt since it's timestamp, and issuer, metadataHistory, provenance with id, originTxHash
+// ignoring createdAt and updatedAt since it's timestamp, metadataHistory, provenance with id, originTxHash
 test("srrs", async () => {
   const query = `
   {
     srrs {
       id
       tokenId
+      artistAddress
+      issuer {
+        id
+        englishName
+      }
       metadataDigest
       transferCommitment
       history {
@@ -49,6 +54,11 @@ test("srrs", async () => {
         "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727252",
       originChain: "eip155:31337",
       tokenId: "10255373",
+      artistAddress: "0xa6e6a9e20a541680a1d6e1412f5088aefbf58a22",
+      issuer: {
+        id: "0xf157e8b5d7a4b3fda8c2f7c19b4a57be32ec0392",
+        englishName: "New English Name"
+      },
       transferCommitment: null
     }),
     expect.objectContaining({
@@ -63,6 +73,11 @@ test("srrs", async () => {
         "0x5b985b5b195a77df122842687feb3fa0136799d0e7a6e7394adf504526727251",
       originChain: "eip155:31337",
       tokenId: "43593516",
+      artistAddress: "0xa6e6a9e20a541680a1d6e1412f5088aefbf58a22",
+      issuer: {
+        id: "0xf157e8b5d7a4b3fda8c2f7c19b4a57be32ec0392",
+        englishName: "New English Name"
+      },
       transferCommitment: null
     }),
     expect.objectContaining({
@@ -72,6 +87,11 @@ test("srrs", async () => {
         "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
       originChain: "eip155:31337",
       tokenId: "80626184",
+      artistAddress: "0x66c0d9152209b51977047b9dc3b0b5bf2339b67c",
+      issuer: {
+        id: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
+        englishName: "Artist English"
+      },
       transferCommitment: null
     })
   ]
@@ -92,6 +112,7 @@ test("licensedUserWallets ", async () => {
   const query = `
   {
     licensedUserWallets {
+      id
       threshold
       englishName
       originalName
@@ -112,6 +133,7 @@ test("licensedUserWallets ", async () => {
 
   const data = [
     {
+      id: "0x864d38b2989553080dbe893f7366b2dc675cac1f",
       englishName: "Artist English",
       issuedSRRs: [
         {
@@ -134,6 +156,7 @@ test("licensedUserWallets ", async () => {
       userType: "artist"
     },
     {
+      id: "0xf157e8b5d7a4b3fda8c2f7c19b4a57be32ec0392",
       englishName: "New English Name",
       issuedSRRs: [
         {

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -71,7 +71,7 @@ test("srrs", async () => {
         englishName: "Artist English"
       },
       transferCommitment: null,
-      lockExternalTransfer: true
+      lockExternalTransfer: false
     }),
     expect.objectContaining({
       history: [
@@ -116,7 +116,7 @@ test("srrs", async () => {
         englishName: "New English Name"
       },
       transferCommitment: null,
-      lockExternalTransfer: false
+      lockExternalTransfer: true
     })
   ]
 
@@ -209,29 +209,7 @@ test("licensedUserWallets ", async () => {
         "0x64e604787cbf194841e7b68d7cd28786f6c9a0a3ab9f8b0a0e87cb4387ab0002",
       threshold: 1,
       userType: "handler"
-    },
-    {
-      englishName: "Artist English",
-      issuedSRRs: [
-        {
-          id: "80626184",
-          metadataDigest: "0x4c8f18581c0167eb90a761b4a304e009b924f03b619a0c0e8ea3adfce20aee64",
-          tokenId: "80626184",
-          transferCommitment: null,
-        }
-      ],
-      originChain: null,
-      originalName: "Artist Original",
-      owners: [
-        "0x853f2251666f9d8c45cc760ae10ab0278533d28c",
-        "0x171ea52e619b7fdde870b328ccfb70217a3e32ae",
-        "0xad87f0b51a8788192edd0640ab5ed58e48145c82"
-      ],
-      salt:
-        "0x64e604787cbf194841e7b68d7cd28786f6c9a0a3ab9f8b0a0e87cb4387ab0001",
-      threshold: 1,
-      userType: "artist"
-    },
+    }
   ]
   expect(result.licensedUserWallets).toStrictEqual(data)
 })
@@ -474,6 +452,11 @@ test("metaTxRequestTypes", async () => {
       typeString:
         "StartrailRegistrySetLockExternalTransfer(address from,uint256 nonce,uint256 tokenId,bool flag)"
     },
+    {
+      "id": "0x98ce74b76cbcc5f7fc9d14949a70627b5dc8b6d1ff04fc70f34c4839ccdabf11",
+      "typeHash": "0x98ce74b76cbcc5f7fc9d14949a70627b5dc8b6d1ff04fc70f34c4839ccdabf11",
+      "typeString": "StartrailRegistryCreateSRRWithLockExternalTransfer(address from,uint256 nonce,bool isPrimaryIssuer,address artistAddress,bytes32 metadataDigest,bool lockExternalTransfer)",
+    }
     // for decentalized storage
     // {
     //   id: "0xa5772716d883ea9d1e653c127fc4b5f193148ae32c6699efdcdba6fa2a242f4f",
@@ -578,7 +561,7 @@ test("srrprovenances", async () => {
       metadataDigest: "0x",
       metadataURI: "",
       srr: {
-        id: "10255373",
+        id: "67251424",
       },
     }
   ]


### PR DESCRIPTION
related: https://github.com/startbahn/startrail/pull/412

## Objective

To add LicensedUserWallet entity of the artist under SRR.

Refactored testing a bit.
- stopped validating `id` of `SRRHistory`. Its SRR's `id`, custom history's `metadataDigest` or its `id` is worth doing so.
- added some `orderBy`. Without it, the contents in an array often swap and a test unnecessarily fails.