### PR TITLE
bump local graph node to deployed graph node version 0.23.0

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   graph-node:
     container_name: subgraph-node
-    image: graphprotocol/graph-node:v0.22.0
+    image: graphprotocol/graph-node:v0.23.0
     ports:
       - "8000:8000"
       - "8001:8001"


### PR DESCRIPTION
Sync up so we are testing locally with the same version.